### PR TITLE
fix:remove install scikit-learn

### DIFF
--- a/MP2/setup_models.sh
+++ b/MP2/setup_models.sh
@@ -4,7 +4,7 @@ pip3 install peft==0.4.0
 pip3 install accelerate==0.21.0
 pip3 install einops==0.6.1
 pip3 install evaluate==0.4.0
-pip3 install scikit-learn==1.2.2
+# pip3 install scikit-learn==1.2.2
 pip3 install sentencepiece==0.1.99
 pip3 install wandb==0.15.3
 pip3 install jsonlines


### PR DESCRIPTION
"pip3 install scikit-learn==1.2.2" is not necessary, and I observe that sometimes Colab gets hung up when installing this dependency.
